### PR TITLE
IW-2696 | Add Parsoid native extension to render portable infoboxes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 def namespace = "dev"
-def targets = ["sjc", "poz"]
+def targets = ["poz", "sjc"]
 // DEV slack channel as a default
 def slackChannel = "#services-deploy-dev"
 def isDevEnv = true
@@ -16,7 +16,7 @@ if (params.environment == "prod") {
 }
 
 def deployenv = 'artifactory.wikia-inc.com/platform/alpine:3.6-curl'
-def kubectl = 'artifactory.wikia-inc.com/ops/k8s-deployer:0.0.24'
+def kubectl = 'artifactory.wikia-inc.com/ops/k8s-deployer:0.0.25'
 
 node('docker-daemon'){
     def serviceVersion = "0.0.0"
@@ -36,7 +36,7 @@ node('docker-daemon'){
     }
 
     stage('Check if image already exists'){
-        serviceVersion = sh(script: "git describe --tags --long 2> /dev/null || echo v0.1.0", returnStdout: true).trim()
+        serviceVersion = sh(script: "git rev-parse --short HEAD", returnStdout: true).trim()
         def status = sh(script: "curl -u ${env.JENKINS_ARTIFACTORY_USERNAME}:${env.JENKINS_ARTIFACTORY_PASSWORD}  -w \"%{http_code}\" -s -I -o /dev/null -XGET \"https://artifactory.wikia-inc.com/artifactory/api/storage/dockerv2-local/services/unified-platform-parsoid/${serviceVersion}\"", returnStdout: true).trim()
         if ( status == "200" ){
             println "Image ${imageName}:${serviceVersion} already exists"

--- a/lib/ext/Infobox/index.js
+++ b/lib/ext/Infobox/index.js
@@ -42,13 +42,10 @@ class PostProcessingPortableInfoboxRenderer {
 		potentialInfoboxNodes.forEach(node => {
 			// Only handle actual infoboxes and not any <aside> tags
 			if (DOMUtils.hasTypeOf(node, 'mw:Extension/infobox')) {
+				// Only handle <infobox> tags rendered via template transclusions
 				if (DOMUtils.hasTypeOf(node, 'mw:Transclusion')) {
 					// Found an <infobox> included on the page as a template - we can handle it
 					actualInfoboxNodes.push(node);
-				} else {
-					// Found an <infobox> tag that is not rendered via a template transclusion
-					// It's not really clear what could be done with it - so discard it
-					node.parentNode.removeChild(node);
 				}
 			}
 		});

--- a/lib/ext/Infobox/index.js
+++ b/lib/ext/Infobox/index.js
@@ -1,0 +1,111 @@
+'use strict';
+/**
+ * Parsoid native extension that allows Parsoid to properly render portable infoboxes by delegating rendering
+ * to the MediaWiki PHP parser.
+ */
+
+const {
+	DOMUtils, DOMDataUtils, Promise, parseTokenContentsToDOM
+} = module.parent.require('./extapi.js').versionCheck('^0.10.0');
+
+/**
+ * Inject a placeholder for each <infobox> into the DOM, to be handled at the post-processing stage.
+ *
+ * @param state parsing pipeline context
+ * @param content raw text content of the <infobox> tag
+ * @param attributes attributes set on the <infobox> tag
+ * @return {*|PromiseLike<Document>|Promise<Document>}
+ */
+const toDOM = function (state, content, attributes) {
+	return parseTokenContentsToDOM(state, [], '', '', {
+		wrapperTag: 'aside',
+		pipelineOpts: {
+			extTag: 'infobox',
+		},
+	});
+};
+
+/**
+ * DOM post-processor that operates on the complete HTML5 document constructed by Parsoid from the input content.
+ */
+class PostProcessingPortableInfoboxRenderer {
+	run(node, env, options, atTopLevel) {
+		if (!atTopLevel) {
+			return;
+		}
+
+		const document = node.ownerDocument;
+		const potentialInfoboxNodes = Array.from(document.getElementsByTagName('aside'));
+
+		const actualInfoboxNodes = [];
+
+		potentialInfoboxNodes.forEach(node => {
+			// Only handle actual infoboxes and not any <aside> tags
+			if (DOMUtils.hasTypeOf(node, 'mw:Extension/infobox')) {
+				if (DOMUtils.hasTypeOf(node, 'mw:Transclusion')) {
+					// Found an <infobox> included on the page as a template - we can handle it
+					actualInfoboxNodes.push(node);
+				} else {
+					// Found an <infobox> tag that is not rendered via a template transclusion
+					// It's not really clear what could be done with it - so discard it
+					node.parentNode.removeChild(node);
+				}
+			}
+		});
+
+		const infoboxParseRequests = [];
+
+		/**
+		 * Create a wikitext template invocation and push it to the queue of infoboxes to be parsed
+		 * @param template template transclusion metadata from Parsoid
+		 */
+		const pushWikitextTemplateInvocation = ({ template }) => {
+			// build wikitext for transclusion params
+			const paramsAsText = Object.entries(template.params).reduce(
+				(accum, [paramName, value]) => accum + `|${paramName}=${value.wt}`, ''
+			);
+
+			const invocation = `{{${template.target.wt}${paramsAsText}}}`;
+			const phpParseRequest = env.batcher.parse(env.page.name, invocation);
+
+			infoboxParseRequests.push(phpParseRequest);
+		};
+
+		// Process each <infobox> template transclusion and issue a request to render them via the MW PHP parser
+		actualInfoboxNodes.forEach(node => {
+			const metaInfo = DOMDataUtils.getDataMw(node);
+
+			metaInfo.parts.forEach(pushWikitextTemplateInvocation);
+		});
+
+		// Parse all infoboxes in parallel and inject their contents back into the document
+		return Promise.all(infoboxParseRequests)
+			.then(htmlContents => {
+				htmlContents.forEach((html, i) => {
+					const docFromMw = DOMUtils.parseHTML(html);
+
+					// only import the infobox and discard other template contents to avoid duplication
+					const portableInfobox = docFromMw.querySelector('.portable-infobox');
+					const imported = document.importNode(portableInfobox, true);
+
+					// add the rendered infobox to the output document in the proper location
+					actualInfoboxNodes[i].appendChild(imported);
+				})
+			});
+	}
+}
+
+module.exports = function() {
+	this.config = {
+		name: 'infobox',
+		domProcessors: {
+			wt2htmlPostProcessor: PostProcessingPortableInfoboxRenderer,
+		},
+		tags: [
+			{
+				name: 'infobox',
+				toDOM,
+			},
+		],
+	};
+};


### PR DESCRIPTION
Add a Parsoid plugin that allows rendering portable infoboxes inside the VE. Because Parsoid delegates template expansion to the PHP preprocessor via an API call, information about template frame arguments is unfortunately not available at the time of extension tag rendering. This forces us to use an HTML DOM post-processor to inject rendered portable infoboxes into the document at a later stage, when template transclusion metadata can be fetched from the constructed DOM.

The actual rendering is implemented by delegating the actual work to the MW PHP parser.

https://wikia-inc.atlassian.net/browse/IW-2696