### PR TITLE
Add statsd->prom bridge to parsoid

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ node_modules/
 tools/
 .jsduck/
 .idea/
+Jenkinsfile
+k8s.yaml
+

--- a/config.yaml
+++ b/config.yaml
@@ -3,8 +3,10 @@ worker_heartbeat_timeout: 300000
 logging:
     level: info
 
-#metrics:
-#    type: log
+metrics:
+  type: statsd
+  host: localhost
+  port: 9125
 
 services:
   - module: lib/index.js

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -9,8 +9,13 @@ metadata:
 spec:
   ports:
   - port: 80
+    name: main
     protocol: TCP
     targetPort: 8080
+  - port: 9102
+    name: metrics
+    protocol: TCP
+    targetPort: 9102
   selector:
     app: unified-platform-parsoid
   type: ClusterIP
@@ -61,6 +66,56 @@ spec:
             port: 8080
         ports:
         - containerPort: 8080
+      - name: statsd-exporter
+        image: "prom/statsd-exporter:v0.13.0"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 100Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+        livenessProbe:
+          httpGet:
+            port: 9102
+            path: /metrics
+          initialDelaySeconds: 20
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 9102
+          timeoutSeconds: 3
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+        ports:
+          - containerPort: 9102
+          - containerPort: 9125
+            protocol: TCP
+          - containerPort: 9125
+            protocol: UDP
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: unified-platform-parsoid
+  labels:
+    app: unified-platform-parsoid
+  namespace: ${env}
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: unified-platform-parsoid
+  namespaceSelector:
+    matchNames:
+      - ${env}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 10s
 
 ---
 apiVersion: networking.k8s.io/v1beta1


### PR DESCRIPTION
Parsoid publishes its own metrics via statsd, but we use Prometheus
for metrics collection. Let's add a statsd exporter to the Parsoid
deployment so that we can get these metrics into our monitoring system.

As we're here, make the Docker image build ignore irrelevant config files.