### PR TITLE
increase metrics scrape interval

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -115,7 +115,7 @@ spec:
   endpoints:
     - port: metrics
       path: /metrics
-      interval: 10s
+      interval: 30s
 
 ---
 apiVersion: networking.k8s.io/v1beta1


### PR DESCRIPTION
Per @r0bj we should use an interval of 30s for Prometheus metrics collection, as it is our default.