### PR TITLE
IW-2729 | Enable batch API for MediaWiki calls

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,3 +16,6 @@ services:
 
         # Use selective serialization (default false)
         useSelser: true
+        
+        # IW-2729: Use batch API interface for communicating with MediaWiki
+        useBatchAPI: true


### PR DESCRIPTION
Allow Parsoid to leverage the ParsoidBatchAPI extension's more efficient interface for its calls to MediaWiki.

Merge after https://github.com/Wikia/unified-platform/pull/716 is deployed.