### PR TITLE
IW-3041 | Match Parsoid's max wikitext size to MediaWiki's $wgMaxArticleSize value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,11 @@ services:
 
         # Use selective serialization (default false)
         useSelser: true
-        
+
         # IW-2729: Use batch API interface for communicating with MediaWiki
         useBatchAPI: true
+
+        limits:
+          wt2html:
+            # IW-3041: Match Parsoid's max wikitext size to MediaWiki's $wgMaxArticleSize value - 2 MiB
+            maxWikitextSize: 2000000


### PR DESCRIPTION
Parsoid uses a configuration setting limits.wt2html.maxWikitextSize that
sets the maximum size of wikitext content it will accept for parsing.
By default, this is set to 1 MiB, meaning articles with more than 1 MiB
of wikitext content won't be parseable via Parsoid and so will be uneditable
via the VisualEditor.

However, by default MediaWiki allows articles to have up to 2 MiB wikitext
content, as set by $wgMaxArticleSize. This can lead to a situation where
an article is uneditable in the VisualEditor due to it being over Parsoid's
limit, but below MediaWiki's limit.

As a fix, increase limits.wt2html.maxWikitextSize to match MediaWiki's value,
i.e. 2 MiB.

https://wikia-inc.atlassian.net/browse/IW-3041