### PR TITLE
IW-3036 | Support main page tags in Parsoid

### DIFF
--- a/lib/config/localSettings.js
+++ b/lib/config/localSettings.js
@@ -8,8 +8,12 @@ module.exports = {
 	 * @param {ParsoidConfig} parsoidConfig
 	 */
 	setup: function(parsoidConfig) {
+		if (!process.env.ENV || process.env.CI) {
+			return; // no environment given - parser tests?
+		}
+
 		const isDevEnv = (process.env.ENV === 'dev');
-		// epic hack
+
 		parsoidConfig.mwApiMap = new WikiaApiMap();
 		parsoidConfig.reverseMwApiMap = new WikiaReverseApiMap();
 

--- a/lib/ext/MainPageTag/index.js
+++ b/lib/ext/MainPageTag/index.js
@@ -1,0 +1,253 @@
+'use strict';
+
+const ParsoidExtApi = module.parent.require('./extapi.js').versionCheck('^0.10.0');
+
+const { DOMDataUtils, DOMUtils, Promise } = ParsoidExtApi;
+
+/**
+ * @typedef ParserState {Object}
+ * @property {MWParserEnvironment} env
+ */
+
+/**
+ * Render a blank <mainpage-leftcolumn-start /> tag - contents will be added in post processing
+ * @param {ParserState} state
+ * @return {Promise<Document>}
+ */
+function renderMainPageLeftColumnStart(state) {
+	const doc = state.env.createDocument();
+
+	const lcsContainer = doc.createElement('div');
+	lcsContainer.classList.add('lcs-container');
+
+	const leftColumnStart = doc.createElement('div');
+	leftColumnStart.classList.add('main-page-tag-lcs');
+	leftColumnStart.appendChild(lcsContainer);
+
+	doc.body.appendChild(leftColumnStart);
+
+	return Promise.resolve(doc);
+}
+
+/**
+ * Render a blank <mainpage-rightcolumn-start /> tag - contents will be added in post processing
+ * @param {ParserState} state
+ * @return {Promise<Document>}
+ */
+function renderMainPageRightColumnStart(state) {
+	const doc = state.env.createDocument();
+
+	const rcsContainer = doc.createElement('div');
+	rcsContainer.classList.add('rcs-container');
+
+	const rightColumnStart = doc.createElement('div');
+	rightColumnStart.classList.add('main-page-tag-rcs');
+	rightColumnStart.appendChild(rcsContainer);
+
+	doc.body.appendChild(rightColumnStart);
+
+	return Promise.resolve(doc);
+}
+
+/**
+ * Render a placeholder node for <mainpage-endcolumn /> tag - will be removed during post-processing
+ * @param {ParserState} state
+ * @return {Promise<Document>}
+ */
+function renderMainPageEndColumnPlaceholder(state) {
+	const doc = state.env.createDocument();
+
+	const placeholder = doc.createElement('div');
+	doc.body.appendChild(placeholder);
+
+	return Promise.resolve(doc);
+}
+
+class MainPageTagDomPostProcessor {
+	/**
+	 * wt2html DOM post processor that shifts content to the proper column when main page tag columns are present.
+	 *
+	 * @param {HTMLElement} body
+	 * @param {MWParserEnvironment} env
+	 * @param {Object} options
+	 * @param {boolean} atTopLevel
+	 */
+	run(body, env, options, atTopLevel) {
+		if (!atTopLevel) {
+			return;
+		}
+
+		/**
+		 * @typedef {Object} MainPageTagProcessorState
+		 * @property {?Node} leftColumnTag
+		 * @property {?Node} rightColumnTag
+		 * @property {boolean} leftColumnTagClosed
+		 * @property {boolean} rightColumnTagClosed
+		 */
+
+		const state = {
+			leftColumnTag: null,
+			rightColumnTag: null,
+			leftColumnTagClosed: false,
+			rightColumnTagClosed: false,
+		};
+
+		// Process the content and move elements to the appropriate columns
+		this.process(body, state);
+
+		if (state.leftColumnTag) {
+			DOMUtils.visitDOM(state.leftColumnTag, this.preserveNowikis, env);
+		}
+
+		if (state.rightColumnTag) {
+			DOMUtils.visitDOM(state.rightColumnTag, this.preserveNowikis, env);
+		}
+	}
+
+	/**
+	 * Hack: Preserve <nowiki> tags present in main page column content
+	 * by assigning them a fake about-ID so that they do not get stripped during cleanup.
+	 *
+	 * @param {HTMLElement} node
+	 * @param {MWParserEnvironment} env
+	 */
+	preserveNowikis(node, env) {
+		if (DOMUtils.matchTypeOf(node, /^mw:Nowiki$/)) {
+			const aboutId = env.newAboutId();
+			node.setAttribute('about', aboutId);
+		}
+	}
+
+	/**
+	 * Close a column tag if it was open, and shift its DOM source range to encompass the entire wikitext until its closing tag
+	 * @param {Node} node
+	 * @param {boolean} wasClosed
+	 * @param {Node} closingTag
+	 * @return {boolean} whether we closed the node
+	 */
+	closeColumnTagIfOpen(node, wasClosed, closingTag) {
+		if (!node || wasClosed) {
+			return wasClosed; // node wasn't open or we already closed it
+		}
+
+		const { dsr } = DOMDataUtils.getDataParsoid(closingTag);
+		const [, closeTagEnd] = dsr;
+
+		const columnDataParsoid = DOMDataUtils.getDataParsoid(node);
+		const [start, , openWidth, closeWidth] = columnDataParsoid.dsr;
+
+		columnDataParsoid.dsr = [start, closeTagEnd, openWidth, closeWidth];
+
+		return true;
+	}
+
+	/**
+	 * Recursively process an HTML node and move children to main page column tags as appropriate
+	 * @param {Node} node
+	 * @param {MainPageTagProcessorState} state
+	 */
+	process(node, state) {
+		let child = node.firstChild;
+
+		while (child !== null) {
+			const nextSibling = child.nextSibling;
+
+			if (DOMUtils.matchTypeOf(child, /^mw:Extension\/mainpage-leftcolumn-start$/)) {
+				// Found left column tag
+				state.leftColumnTag = child;
+				const leftColumnClass = state.rightColumnTag ? 'main-page-tag-lcs-collapsed' : 'main-page-tag-lcs-exploded';
+				state.leftColumnTag.classList.add(leftColumnClass);
+
+				// Close any open right column tags
+				state.rightColumnTagClosed = this.closeColumnTagIfOpen(state.rightColumnTag, state.rightColumnTagClosed, child);
+			} else if (DOMUtils.matchTypeOf(child, /^mw:Extension\/mainpage-rightcolumn-start$/)) {
+				// Found right column tag
+				state.rightColumnTag = child;
+
+				// Close any open left column tags
+				state.leftColumnTagClosed = this.closeColumnTagIfOpen(state.leftColumnTag, state.leftColumnTagClosed, child);
+			} else if (DOMUtils.matchTypeOf(child, /^mw:Extension\/mainpage-endcolumn$/)) {
+				// Found end column tag - close any open tags
+				state.leftColumnTagClosed = this.closeColumnTagIfOpen(state.leftColumnTag, state.leftColumnTagClosed, child);
+				state.rightColumnTagClosed = this.closeColumnTagIfOpen(state.rightColumnTag, state.rightColumnTagClosed, child);
+
+				// Remove end column placeholder
+				child.remove();
+			} else if (state.leftColumnTag && !state.leftColumnTagClosed) {
+				// there's an open left column - shift content into it
+				state.leftColumnTag.firstChild.appendChild(child);
+			} else if (state.rightColumnTag && !state.rightColumnTagClosed) {
+				// there's an open right column - shift content into it
+				state.rightColumnTag.firstChild.appendChild(child);
+			} else if (DOMUtils.isElt(child)) {
+				// no columns are open - descend recursively into child node to search for columns
+				this.process(child, state);
+			}
+
+			child = nextSibling;
+		}
+	}
+}
+
+const serialHandler = {
+	/**
+	 * Serialize a main page tag HTML node back to wikitext
+	 *
+	 * @param {Node} node
+	 * @param {SerializerState} state
+	 * @return {Promise<string>}
+	 */
+	handle: Promise.async(function *(node, state) {
+		const container = node.firstChild;
+
+		// Stash child metadata in the DOM so that it is available for the serializer
+		DOMDataUtils.visitAndStoreDataAttribs(container);
+
+		const [startTag, content] = yield Promise.all([
+			state.serializer.serializeExtensionStartTag(node, state),
+			state.serializer.serializeHTML({ env: state.env }, container.innerHTML),
+		]);
+
+		return startTag + content + '<mainpage-endcolumn />';
+	}),
+};
+
+/**
+ * Modify metadata applied to main page tag extension nodes
+ *
+ * @param {MWParserEnvironment} env
+ * @param {Object} argDict - metadata to be associated with this extension node
+ */
+function modifyArgDict(env, argDict) {
+	delete argDict.body; // always treat these as self-closing tags
+}
+
+module.exports = function() {
+	this.config = {
+		name: 'MainPageTag',
+		domProcessors: {
+			wt2htmlPostProcessor: MainPageTagDomPostProcessor
+		},
+		tags: [
+			{
+				name: 'mainpage-leftcolumn-start',
+				toDOM: renderMainPageLeftColumnStart,
+				serialHandler,
+				modifyArgDict,
+			},
+			{
+				name: 'mainpage-rightcolumn-start',
+				toDOM: renderMainPageRightColumnStart,
+				serialHandler,
+				modifyArgDict,
+			},
+			{
+				name: 'mainpage-endcolumn',
+				toDOM: renderMainPageEndColumnPlaceholder,
+			}
+		],
+		styles: [
+			'ext.fandom.mainPageTag.css',
+		],
+	};
+};

--- a/tests/mainPageTagParserTests.txt
+++ b/tests/mainPageTagParserTests.txt
@@ -1,0 +1,159 @@
+# Force the test runner to ensure the extension is loaded
+!! hooks
+mainpage-leftcolumn-start
+mainpage-rightcolumn-start
+mainpage-endcolumn
+!! endhooks
+
+!! test
+basic main page
+!! wikitext
+<mainpage-leftcolumn-start />
+==Left column==
+Lorem ipsum dolor.
+<div class="content">Foo</div>
+<mainpage-endcolumn />
+<mainpage-rightcolumn-start />
+==Right column==
+Baz
+<mainpage-endcolumn />
+!! html/parsoid
+<div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt3" data-parsoid='{"dsr":[0,29,29,0]}' data-mw='{"name":"mainpage-leftcolumn-start","attrs":{}}'><div class="lcs-container" data-parsoid="{}">
+<h2 id="Left_column" data-parsoid='{"dsr":[30,47,2,2]}'>Left column</h2>
+<p data-parsoid='{"dsr":[48,66,0,0]}'>Lorem ipsum dolor.</p>
+<div class="content" data-parsoid='{"stx":"html","dsr":[67,97,21,6]}'>Foo</div>
+</div></div>
+<div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt9" data-parsoid='{"dsr":[121,151,30,0]}' data-mw='{"name":"mainpage-rightcolumn-start","attrs":{}}'><div class="rcs-container" data-parsoid="{}">
+<h2 id="Right_column" data-parsoid='{"dsr":[152,170,2,2]}'>Right column</h2>
+<p data-parsoid='{"dsr":[171,174,0,0]}'>Baz</p>
+</div></div>
+!! end
+
+!! test
+main page column with <nowiki>
+!! wikitext
+<mainpage-leftcolumn-start />
+Lorem ipsum<nowiki>'''Preserve me!'''</nowiki> dolor sit amet
+<mainpage-endcolumn />
+<mainpage-rightcolumn-start />
+Right column
+<mainpage-endcolumn />
+!! html/parsoid
+<div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[0,29,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[30,93,0,0]}">Lorem ipsum<span typeof="mw:Nowiki" about="#mwt15" data-parsoid="{&quot;dsr&quot;:[42,77,8,9]}">'''Preserve me!'''</span> dolor sit amet</p>
+</div></div>
+<div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt11" data-parsoid="{&quot;dsr&quot;:[117,148,30,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-rightcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="rcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[149,163,0,0]}">Right column</p>
+</div></div>
+!! end
+
+!! test
+main page left column only
+!! wikitext
+<mainpage-leftcolumn-start />
+Only left column
+<mainpage-endcolumn />
+!! html/parsoid
+<div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[0,29,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[30,48,0,0]}">Only left column</p>
+</div></div>
+!! end
+
+!! test
+main page right column before left column
+!! wikitext
+<mainpage-rightcolumn-start />
+Right column before left!
+<mainpage-endcolumn />
+<mainpage-leftcolumn-start />
+Left column after right!
+<mainpage-endcolumn />
+!! html/parsoid
+<div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[0,30,30,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-rightcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="rcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[31,58,0,0]}">Right column before left!</p>
+</div></div>
+<div class="main-page-tag-lcs main-page-tag-lcs-collapsed" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt9" data-parsoid="{&quot;dsr&quot;:[82,112,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[113,139,0,0]}">Left column after right!</p>
+</div></div>
+!! end
+
+!! test
+main page columns wrapped in custom HTML
+!! wikitext
+<div class="wrapper">
+<div class="foo">
+<mainpage-leftcolumn-start />
+Left column
+<mainpage-endcolumn />
+<mainpage-rightcolumn-start />
+Right column
+<mainpage-endcolumn />
+</div>
+</div>
+!! html/parsoid
+<div class="wrapper" data-parsoid="{&quot;stx&quot;:&quot;html&quot;,&quot;dsr&quot;:[0,194,21,6]}">
+<div class="foo" data-parsoid="{&quot;stx&quot;:&quot;html&quot;,&quot;dsr&quot;:[23,186,17,6]}">
+<div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[42,71,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[72,85,0,0]}">Left column</p>
+</div></div>
+<div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt9" data-parsoid="{&quot;dsr&quot;:[109,140,30,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-rightcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="rcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[141,155,0,0]}">Right column</p>
+</div></div>
+</div>
+</div>
+!! end
+
+!! test
+main page column with unbalanced left column opening tag is normalized
+!! options
+# don't do wt2wt roundtripping since we normalize by inserting the missing closing tag
+parsoid=wt2html,html2html
+!! wikitext
+<mainpage-leftcolumn-start />
+Left column
+<mainpage-rightcolumn-start />
+Right column
+<mainpage-endcolumn />
+!! html
+<div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[0,74,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[30,43,0,0]}">Left column</p>
+</div></div><div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt6" data-parsoid="{&quot;dsr&quot;:[44,112,30,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-rightcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="rcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[75,89,0,0]}">Right column</p>
+</div></div>
+!! end
+
+!! test
+main page column with unbalanced right column opening tag is normalized
+!! options
+# don't do wt2wt roundtripping since we normalize by inserting the missing closing tag
+parsoid=wt2html,html2html
+!! wikitext
+<mainpage-rightcolumn-start />
+Right column
+<mainpage-leftcolumn-start />
+Left column
+<mainpage-endcolumn />
+!! html
+<div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[0,75,30,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-rightcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="rcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[31,45,0,0]}">Right column</p>
+</div></div><div class="main-page-tag-lcs main-page-tag-lcs-collapsed" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt6" data-parsoid="{&quot;dsr&quot;:[46,112,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[76,89,0,0]}">Left column</p>
+</div></div>
+!! end
+
+!! test
+main page stray closing column tag is stripped
+!! options
+# don't do wt2wt roundtripping since we normalize by stripping the extraneous closing tag
+parsoid=wt2html,html2html
+!! wikitext
+<mainpage-leftcolumn-start />
+Left column
+<mainpage-endcolumn />
+
+<mainpage-endcolumn />
+!! html
+<div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[0,66,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
+<p data-parsoid="{&quot;dsr&quot;:[30,43,0,0]}">Left column</p>
+</div></div>
+!! end

--- a/tests/parserTests.json
+++ b/tests/parserTests.json
@@ -26,5 +26,8 @@
 		"path": "tests/parser/parserTests.txt",
 		"expectedSHA1": "da480d0032f2b24a8c48bac5417f8c3bc52d48ee",
 		"latestCommit": "bc7b145051a0de0f3be0aa3d861cc8b633f99e11"
+	},
+	"mainPageTagParserTests.txt": {
+
 	}
 }


### PR DESCRIPTION
Add basic Parsoid support for main page column tags.
Because these tags are stateful, we need to implement them in a
DOM post processing step where we shift content into the columns
as needed.

There are a few differences from the PHP implementation in that
this implementation will always return well-formed HTML	(as mandated
by Parsoid), and it will always normalize invalid usages of main page
columns, i.e. it will add missing <mainpage-endcolumn /> tags to wikitext
and remove dangling <mainpage-endcolumn /> tags without a corresponding
start tag.