### PR TITLE
IW-3184 | Reduce number of parsoid workers and increase replicas

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 worker_heartbeat_timeout: 300000
+num_workers: 4
 
 logging:
     level: info

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -30,11 +30,11 @@ spec:
   selector:
     matchLabels:
       app: unified-platform-parsoid
-  replicas: 1
+  replicas: 4
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 50%
       maxUnavailable: 0
   minReadySeconds: 5
   template:
@@ -67,7 +67,7 @@ spec:
         ports:
         - containerPort: 8080
       - name: statsd-exporter
-        image: "prom/statsd-exporter:v0.13.0"
+        image: "prom/statsd-exporter:v0.15.0"
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
Parsoid uses the service-runner library to start up a number of workers
to serve traffic. By default, it starts one worker per available CPU core.
In a container context, this is not desired, as the library reads the
available CPU cores on the host, rather than the actual CPU resources
available to the container after resource limits are applied.
Thus, we end up spawning too many processes, exhausting the memory limit
of the container.

As a fix, use a fixed low number of workers (4) per container,
and increase the number of deployment replicas to improve resiliency.