### PR TITLE
Fix observed crash in Infobox processing

### DIFF
--- a/lib/ext/Infobox/index.js
+++ b/lib/ext/Infobox/index.js
@@ -77,9 +77,10 @@ class PostProcessingPortableInfoboxRenderer {
 
 		// Process each <infobox> template transclusion and issue a request to render them via the MW PHP parser
 		actualInfoboxNodes.forEach((node) => {
-			const metaInfo = DOMDataUtils.getDataMw(node);
+			const { parts } = DOMDataUtils.getDataMw(node);
+			const [templateInvocation] = parts;
 
-			metaInfo.parts.forEach(pushWikitextTemplateInvocation);
+			pushWikitextTemplateInvocation(templateInvocation);
 		});
 
 		// Parse all infoboxes in parallel and inject their contents back into the document


### PR DESCRIPTION
When a portable infobox template transclusion is on the same line as some other
wikitext fragment, the data-mw attribute for the resultant transclusion node
will contain the wikitext fragment in addition to the transclusion metadata.
This then causes an error as the Infobox parser tag handler tries to interpret
ithe wikitext string as a transclusion metadata object.

As a fix, only take the first item from the data-mw attribute of infobox
transclusion nodes and discard any additional ones if they exist, as they're
highly likely to be stray wikitext.

Reproduced on: https://mirysankterinburga.fandom.com/ru/wiki/%D0%AE%D0%BB%D0%B8%D1%8F_%D0%9A%D0%B0%D0%BC%D0%B5%D0%BD%D1%81%D0%BA%D0%B0%D1%8F?oldid=10227