### PR TITLE
IW-4907 | load gallery extension only for gamepedia desktop

### DIFF
--- a/lib/config/MWParserEnvironment.js
+++ b/lib/config/MWParserEnvironment.js
@@ -637,6 +637,7 @@ MWParserEnvironment.prototype.switchToConfig = Promise.async(function *(prefix, 
 	} else {
 		if (!noCache && env.confCache[prefix]) {
 			env.conf.wiki = env.confCache[prefix];
+			env.conf.wiki.loadGamepediaExtensions(env);
 			return; // done!
 		} else if (parsoidConfig.fetchConfig) {
 			resultConf = yield ConfigRequest.promise(env);
@@ -655,6 +656,7 @@ MWParserEnvironment.prototype.switchToConfig = Promise.async(function *(prefix, 
 	}
 
 	env.conf.wiki = new WikiConfig(parsoidConfig, resultConf, prefix);
+	env.conf.wiki.loadGamepediaExtensions(env);
 	env.confCache[prefix] = env.conf.wiki;
 	if (parsoidConfig.fetchConfig) {
 		yield env.conf.wiki.detectFeatures(env);

--- a/lib/config/WikiConfig.js
+++ b/lib/config/WikiConfig.js
@@ -600,34 +600,7 @@ function WikiConfig(parsoidConfig, resultConf, prefix) {
 	this._anchoredProtocolRegex = new RegExp('^(' + alternation + ')', 'i');
 	this._unanchoredProtocolRegex = new RegExp('(?:\\W|^)(' + alternation + ')', 'i');
 
-	// Record info about registered extensions (native and otherwise)
-	this.extConfig = {
-		tags: new Map(), // Extension tags on this wiki, indexed by their aliases.
-		domProcessors: [], // Array since order of running processors might matter
-		styles: new Set(),
-		contentModels: new Map(),
-	};
-	if (resultConf.extensiontags) {
-		var extensions = resultConf.extensiontags;
-		for (var ex = 0; ex < extensions.length; ex++) {
-			// Strip the tag wrappers because we only want the name
-			this.extConfig.tags.set(
-				extensions[ex].replace(/(^<|>$)/g, '').toLowerCase(), null);
-		}
-	}
-
-	// Register native extension handlers second to overwrite the above.
-	this.extConfig.contentModels.set('wikitext', {
-		toHTML: function(env) {
-			// Default: wikitext parser.
-			return env.pipelineFactory.parse(env.page.src);
-		},
-		fromHTML: function(env, body, useSelser) {
-			// Default: wikitext serializer.
-			return FromHTML.serializeDOM(env, body, useSelser);
-		},
-	});
-	mwApiConf.extensions.forEach(config => this.registerExtension(config));
+	this.registerExtensions(mwApiConf.extensions);
 
 	// Somewhat annoyingly, although LanguageConversion is turned on by
 	// default for all WMF wikis (ie, $wgDisableLangConversion = false, as
@@ -694,6 +667,37 @@ function WikiConfig(parsoidConfig, resultConf, prefix) {
 		{ flags: "i" }
 	);
 }
+
+WikiConfig.prototype.registerExtensions = function(extensions) {
+	// Record info about registered extensions (native and otherwise)
+	this.extConfig = {
+		tags: new Map(), // Extension tags on this wiki, indexed by their aliases.
+		domProcessors: [], // Array since order of running processors might matter
+		styles: new Set(),
+		contentModels: new Map(),
+	};
+	if (this.resultConf.extensiontags) {
+		var extensionsTags = this.resultConf.extensiontags;
+		for (var ex = 0; ex < extensions.length; ex++) {
+			// Strip the tag wrappers because we only want the name
+			this.extConfig.tags.set(
+				extensionsTags[ex].replace(/(^<|>$)/g, '').toLowerCase(), null);
+		}
+	}
+
+	// Register native extension handlers second to overwrite the above.
+	this.extConfig.contentModels.set('wikitext', {
+		toHTML: function(env) {
+			// Default: wikitext parser.
+			return env.pipelineFactory.parse(env.page.src);
+		},
+		fromHTML: function(env, body, useSelser) {
+			// Default: wikitext serializer.
+			return FromHTML.serializeDOM(env, body, useSelser);
+		},
+	});
+	extensions.forEach(config => this.registerExtension(config));
+};
 
 WikiConfig.prototype.registerExtension = function(ExtConfig) {
 	var ext = new ExtConfig();
@@ -970,15 +974,19 @@ WikiConfig.prototype.detectFeatures = Promise.async(function *(env) {
  * @return {void}
  */
 WikiConfig.prototype.loadGamepediaExtensions = function(env) {
-	var isMobile = env.mobileve === '1';
 	var isGamepedia = this.resultConf.general.gamepedia === 'true';
 
-	var galleryExtension = ParsoidConfig.prototype.defaultNativeExtensions.find((extension) => {
-		return extension.name === 'Gallery';
-	});
+	if (isGamepedia) {
+		var isMobile = env.mobileve === '1';
+		var extensions = ParsoidConfig.prototype.defaultNativeExtensions;
 
-	if (galleryExtension && isGamepedia && !isMobile) {
-		this.registerExtension(galleryExtension);
+		if (isMobile) {
+			extensions = extensions.filter((extension) => {
+				return extension.name !== 'Gallery';
+			});
+		}
+
+		this.registerExtensions(extensions);
 	}
 };
 

--- a/lib/config/WikiConfig.js
+++ b/lib/config/WikiConfig.js
@@ -678,7 +678,7 @@ WikiConfig.prototype.registerExtensions = function(extensions) {
 	};
 	if (this.resultConf.extensiontags) {
 		var extensionsTags = this.resultConf.extensiontags;
-		for (var ex = 0; ex < extensions.length; ex++) {
+		for (var ex = 0; ex < extensionsTags.length; ex++) {
 			// Strip the tag wrappers because we only want the name
 			this.extConfig.tags.set(
 				extensionsTags[ex].replace(/(^<|>$)/g, '').toLowerCase(), null);

--- a/lib/config/WikiConfig.js
+++ b/lib/config/WikiConfig.js
@@ -15,6 +15,7 @@ var JSUtils = require('../utils/jsutils.js').JSUtils;
 var Promise = require('../utils/promise.js');
 var Util = require('../utils/Util.js').Util;
 var ParamInfoRequest = require('../mw/ApiRequest.js').ParamInfoRequest;
+var ParsoidConfig = require('./ParsoidConfig').ParsoidConfig;
 
 // Make sure our base config is never modified
 JSUtils.deepFreeze(baseConfig);
@@ -36,6 +37,8 @@ function WikiConfig(parsoidConfig, resultConf, prefix) {
 		// Use the default JSON that we've already loaded above.
 		resultConf = baseConfig;
 	}
+
+	this.resultConf = resultConf;
 
 	var general = resultConf.general;
 	var generator = general.generator || '';
@@ -135,12 +138,6 @@ function WikiConfig(parsoidConfig, resultConf, prefix) {
 	this.iwp = prefix || "";
 
 	var mwApiConf = parsoidConfig.mwApiMap.get(prefix);
-
-	// mwApiMap.get might not return all of the native extensions
-	// lack of native Gallery extension breaks VE on gamepedia wikis
-	if (general.gamepedia === 'true') {
-		mwApiConf.extensions = parsoidConfig.defaultNativeExtensions;
-	}
 
 	// The URI for api.php on this wiki.
 	this.apiURI = mwApiConf.uri;
@@ -966,6 +963,24 @@ WikiConfig.prototype.detectFeatures = Promise.async(function *(env) {
 			o => (o && o.name === 'prop' && o.type.indexOf('videoinfo') > -1)
 		);
 });
+
+/**
+ * Load extensions needed by gamepedia wikis
+ * @param {MWParserEnvironment} env
+ * @return {void}
+ */
+WikiConfig.prototype.loadGamepediaExtensions = function(env) {
+	var isMobile = env.mobileve === '1';
+	var isGamepedia = this.resultConf.general.gamepedia === 'true';
+
+	var galleryExtension = ParsoidConfig.prototype.defaultNativeExtensions.find((extension) => {
+		return extension.name === 'Gallery';
+	});
+
+	if (galleryExtension && isGamepedia && !isMobile) {
+		this.registerExtension(galleryExtension);
+	}
+};
 
 if (typeof module === 'object') {
 	module.exports.WikiConfig = WikiConfig;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IW-4907
https://github.com/Wikia/unified-platform/pull/4452

It turned out that loading native gallery extension breaks rendering new galleries on fandom mobile skin, but we still need to load it on the desktop because of this: https://wikia-inc.atlassian.net/browse/IW-4812