### PR TITLE
CATS-613 | Add restart and deadman alerts for Parsoid

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,15 @@ node('docker-daemon'){
 
             def parsoidConfiguration = readFile "k8s.yaml"
 
-            writeFile file: "parsoid-apply.yaml", text: ((new groovy.text.SimpleTemplateEngine().createTemplate(parsoidConfiguration)).make(['replicas':replicas,'env':params.environment,'imageName':imageName, 'datacenter': datacenter]).toString())
+            writeFile file: "parsoid-apply.yaml", text: ((new groovy.text.SimpleTemplateEngine().createTemplate(parsoidConfiguration)).make([
+                    'replicas':replicas,
+                    'env':params.environment,
+                    'imageName':imageName,
+                    'datacenter': datacenter,
+                    'severity': isDevEnv ? 'warning' : 'critical',
+                    'send_pd': !isDevEnv ? 'send' : '""',
+                    'slack_channel': 'cats-alerts'
+            ]).toString())
         }
 
         withDockerContainer(kubectl) {

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -88,3 +88,37 @@ spec:
         backend:
           serviceName: unified-platform-parsoid
           servicePort: 80
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: ${env}
+    role: alert-rules
+    team: iwing
+  name: unified-platform-parsoid
+  namespace: ${env}
+spec:
+  groups:
+    - name: parsoid.rules
+      rules:
+        - alert: parsoid-health-check
+          expr: absent(kube_deployment_status_replicas_available{deployment="unified-platform-parsoid"} > 0)
+          labels:
+            severity: $severity
+            team: iwing
+            slack_channel: $slack_channel
+            pd: ${send_pd}
+          annotations:
+            description: Parsoid service is down
+            summary: Parsoid service has no healthy instances
+        - alert: parsoid-restart
+          annotations:
+            description: "Parsoid restarted ${'{{ $value | humanize }}'} times during last hour"
+          expr: sum(increase(kube_pod_container_status_restarts_total{container="unified-platform-parsoid"}[1h])) > 5
+          labels:
+            severity: warning
+            team: iwing
+            slack_channel: $slack_channel
+            pd: ${send_pd}


### PR DESCRIPTION
Add alerting for Parsoid restart count and availability. For now, use iwing's PD
setup until our team is configured in alertmanager.