### PR TITLE
Tune Parsoid resource usage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 worker_heartbeat_timeout: 300000
-num_workers: 4
+num_workers: 2
 
 logging:
     level: info

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -29,7 +29,7 @@ spec:
   selector:
     matchLabels:
       app: unified-platform-parsoid
-  replicas: 4
+  replicas: $replicas
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -53,7 +53,7 @@ spec:
         resources:
           limits:
             cpu: 5
-            memory: 2.5Gi
+            memory: 3Gi
           requests:
             cpu: 1
             memory: 2Gi


### PR DESCRIPTION
Node.js 10 used by Parsoid will use a 1.4GiB heap on 64-bit systems by default,
disregarding any cgroup memory limits. With 4 workers, the potential maximum
memory usage is significantly higher than the current limit. Accordingly, let's
reduce the worker count to 2 per pod and raise the memory limit to try to
accommodate them better. We can further tune replica count and resource
requests/limits afterwards.