### PR TITLE
CATS-270 | Account for template content before portable infoboxes

### DIFF
--- a/lib/ext/Infobox/index.js
+++ b/lib/ext/Infobox/index.js
@@ -6,7 +6,7 @@
  */
 
 const {
-	DOMUtils, DOMDataUtils, Promise, parseTokenContentsToDOM
+	DOMUtils, DOMDataUtils, Promise, parseTokenContentsToDOM, WTUtils
 } = module.parent.require('./extapi.js').versionCheck('^0.10.0');
 
 /**
@@ -44,16 +44,23 @@ class PostProcessingPortableInfoboxRenderer {
 		const document = node.ownerDocument;
 		const potentialInfoboxNodes = Array.from(document.getElementsByTagName('aside'));
 
-		const actualInfoboxNodes = [];
+		// array of [transclusionStartNode,infoboxNode] 2-tuples
+		const infoboxTransclusions = [];
 
 		potentialInfoboxNodes.forEach((node) => {
 			// Only handle actual infoboxes and not any <aside> tags
-			if (DOMUtils.hasTypeOf(node, 'mw:Extension/infobox')) {
-				// Only handle <infobox> tags rendered via template transclusions
-				if (DOMUtils.hasTypeOf(node, 'mw:Transclusion')) {
-					// Found an <infobox> included on the page as a template - we can handle it
-					actualInfoboxNodes.push(node);
-				}
+			if (!DOMUtils.hasTypeOf(node, 'mw:Extension/infobox')) {
+				return;
+			}
+
+			// If the current node is part of a template transclusion, find the starting node of the transclusion.
+			// Typically this will be the same node as the infobox itself, but this may not be the case if there is
+			// additional content in the template before the infobox, e.g. a category link.
+			const transclusionStartNode = WTUtils.findFirstEncapsulationWrapperNode(node);
+
+			if (transclusionStartNode && DOMUtils.hasTypeOf(transclusionStartNode, 'mw:Transclusion')) {
+				// Found an <infobox> included on the page as a template - we can handle it
+				infoboxTransclusions.push([transclusionStartNode, node]);
 			}
 		});
 
@@ -76,8 +83,8 @@ class PostProcessingPortableInfoboxRenderer {
 		};
 
 		// Process each <infobox> template transclusion and issue a request to render them via the MW PHP parser
-		actualInfoboxNodes.forEach((node) => {
-			const { parts } = DOMDataUtils.getDataMw(node);
+		infoboxTransclusions.forEach(([transclusionStartNode]) => {
+			const { parts } = DOMDataUtils.getDataMw(transclusionStartNode);
 			const [templateInvocation] = parts;
 
 			pushWikitextTemplateInvocation(templateInvocation);
@@ -99,9 +106,10 @@ class PostProcessingPortableInfoboxRenderer {
 					}
 
 					const imported = document.importNode(portableInfobox, true);
+					const [,infoboxNode] = infoboxTransclusions[i];
 
 					// add the rendered infobox to the output document in the proper location
-					actualInfoboxNodes[i].appendChild(imported);
+					infoboxNode.appendChild(imported);
 				});
 			});
 	}

--- a/package.json
+++ b/package.json
@@ -97,5 +97,8 @@
     "dependencies": {
       "_all": []
     }
+  },
+  "volta": {
+    "node": "10.24.0"
   }
 }


### PR DESCRIPTION
Parsoid represents encapsulated content such as template transclusions as a
forest of DOM trees formed by adjacent DOM nodes, where the first node holds the
type and metadata of the encapsulation and subsequent nodes refer to it via an
RDFa about ID. For portable infobox templates, the first node is generally the
infobox itself, being the first or only piece of content in the template, but
there may be other content in the template, such as a category link, preceding
the infobox. This confuses our portable infobox handler, since it assumes that
infoboxes in template transclusions are always the first node inside the
transclusion, so templates that do not fit this expectation are ignored during
rendering.

As a fix, look for the template transclusion start node when processing
potential infobox transclusions during DOM post-processing, instead of assuming
it's always going to be the same node as the infobox itself. Since this means
that the template parameters may no longer be co-located on the infobox node,
store a 2-tuple of [transclusionStartNode,infoboxNode] for each processed
transclusion, so that both the template parameters and the destination node
remain available for subsequent rendering and substitution.