### PR TITLE
CATS-194 | Don't manipulate transcluded main page column DSR offsets

### DIFF
--- a/lib/ext/MainPageTag/index.js
+++ b/lib/ext/MainPageTag/index.js
@@ -2,7 +2,7 @@
 
 const ParsoidExtApi = module.parent.require('./extapi.js').versionCheck('^0.10.0');
 
-const { DOMDataUtils, DOMUtils, Promise } = ParsoidExtApi;
+const { ContentUtils, DOMDataUtils, DOMUtils, Promise } = ParsoidExtApi;
 
 /**
  * @typedef ParserState {Object}
@@ -93,7 +93,7 @@ class MainPageTagDomPostProcessor {
 		};
 
 		// Process the content and move elements to the appropriate columns
-		this.process(body, state);
+		this.process(env, body, state);
 
 		if (state.leftColumnTag) {
 			DOMUtils.visitDOM(state.leftColumnTag, this.preserveNowikis, env);
@@ -120,33 +120,44 @@ class MainPageTagDomPostProcessor {
 
 	/**
 	 * Close a column tag if it was open, and shift its DOM source range to encompass the entire wikitext until its closing tag
-	 * @param {Node} node
+	 * @param {MWParserEnvironment} env
+	 * @param {Node} node opening tag to be closed
 	 * @param {boolean} wasClosed
 	 * @param {Node} closingTag
 	 * @return {boolean} whether we closed the node
 	 */
-	closeColumnTagIfOpen(node, wasClosed, closingTag) {
+	closeColumnTagIfOpen(env, node, wasClosed, closingTag) {
 		if (!node || wasClosed) {
 			return wasClosed; // node wasn't open or we already closed it
 		}
 
-		const { dsr } = DOMDataUtils.getDataParsoid(closingTag);
-		const [, closeTagEnd] = dsr;
+		ContentUtils.shiftDSR(env, node, (origDsr) => {
+			const [start, , openWidth, closeWidth] = origDsr;
+			const { dsr } = DOMDataUtils.getDataParsoid(closingTag);
 
-		const columnDataParsoid = DOMDataUtils.getDataParsoid(node);
-		const [start, , openWidth, closeWidth] = columnDataParsoid.dsr;
+			// If the opening tag is the first encapsulation wrapper node of e.g. a template transclusion
+			// and the closing tag is part of the same transclusion, there will be no DSR offsets set on the closing tag.
+			// There's no need to manipulate DSR offsets for the opening tag here, since they will refer to the template
+			// transclusion statement itself and will therefore be correct.
+			if (!dsr) {
+				return origDsr;
+			}
 
-		columnDataParsoid.dsr = [start, closeTagEnd, openWidth, closeWidth];
+			const [, closeTagEnd] = dsr;
+
+			return [start, closeTagEnd, openWidth, closeWidth];
+		});
 
 		return true;
 	}
 
 	/**
 	 * Recursively process an HTML node and move children to main page column tags as appropriate
+	 * @param {MWParserEnvironment} env
 	 * @param {Node} node
 	 * @param {MainPageTagProcessorState} state
 	 */
-	process(node, state) {
+	process(env, node, state) {
 		let child = node.firstChild;
 
 		while (child !== null) {
@@ -159,17 +170,17 @@ class MainPageTagDomPostProcessor {
 				state.leftColumnTag.classList.add(leftColumnClass);
 
 				// Close any open right column tags
-				state.rightColumnTagClosed = this.closeColumnTagIfOpen(state.rightColumnTag, state.rightColumnTagClosed, child);
+				state.rightColumnTagClosed = this.closeColumnTagIfOpen(env, state.rightColumnTag, state.rightColumnTagClosed, child);
 			} else if (DOMUtils.matchTypeOf(child, /^mw:Extension\/mainpage-rightcolumn-start$/)) {
 				// Found right column tag
 				state.rightColumnTag = child;
 
 				// Close any open left column tags
-				state.leftColumnTagClosed = this.closeColumnTagIfOpen(state.leftColumnTag, state.leftColumnTagClosed, child);
+				state.leftColumnTagClosed = this.closeColumnTagIfOpen(env, state.leftColumnTag, state.leftColumnTagClosed, child);
 			} else if (DOMUtils.matchTypeOf(child, /^mw:Extension\/mainpage-endcolumn$/)) {
 				// Found end column tag - close any open tags
-				state.leftColumnTagClosed = this.closeColumnTagIfOpen(state.leftColumnTag, state.leftColumnTagClosed, child);
-				state.rightColumnTagClosed = this.closeColumnTagIfOpen(state.rightColumnTag, state.rightColumnTagClosed, child);
+				state.leftColumnTagClosed = this.closeColumnTagIfOpen(env, state.leftColumnTag, state.leftColumnTagClosed, child);
+				state.rightColumnTagClosed = this.closeColumnTagIfOpen(env, state.rightColumnTag, state.rightColumnTagClosed, child);
 
 				// Remove end column placeholder
 				child.remove();
@@ -179,9 +190,9 @@ class MainPageTagDomPostProcessor {
 			} else if (state.rightColumnTag && !state.rightColumnTagClosed) {
 				// there's an open right column - shift content into it
 				state.rightColumnTag.firstChild.appendChild(child);
-			} else if (DOMUtils.isElt(child)) {
+			} else if (DOMUtils.isElt(child) && child.hasChildNodes()) {
 				// no columns are open - descend recursively into child node to search for columns
-				this.process(child, state);
+				this.process(env, child, state);
 			}
 
 			child = nextSibling;

--- a/tests/mainPageTagParserTests.txt
+++ b/tests/mainPageTagParserTests.txt
@@ -5,6 +5,31 @@ mainpage-rightcolumn-start
 mainpage-endcolumn
 !! endhooks
 
+!!article
+Template:Home
+!!text
+<mainpage-leftcolumn-start />
+Left column from the template.
+<div class="content">Foo</div>
+<mainpage-endcolumn />
+<mainpage-rightcolumn-start />
+Right column from the template.
+<mainpage-endcolumn />
+!!endarticle
+
+!!article
+Template:HomeWithOtherStuff
+!!text
+[[Category:Some category]]
+<mainpage-leftcolumn-start />
+Left column from the template.
+<div class="content">Foo</div>
+<mainpage-endcolumn />
+<mainpage-rightcolumn-start />
+Right column from the template.
+<mainpage-endcolumn />
+!!endarticle
+
 !! test
 basic main page
 !! wikitext
@@ -156,4 +181,33 @@ Left column
 <div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt3" data-parsoid="{&quot;dsr&quot;:[0,66,29,0]}" data-mw="{&quot;name&quot;:&quot;mainpage-leftcolumn-start&quot;,&quot;attrs&quot;:{}}"><div class="lcs-container" data-parsoid="{}">
 <p data-parsoid="{&quot;dsr&quot;:[30,43,0,0]}">Left column</p>
 </div></div>
+!! end
+
+!! test
+templated main page
+!! wikitext
+{{Home}}
+!! html/parsoid
+<div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start mw:Transclusion" about="#mwt1" data-parsoid='{"pi":[[]],"dsr":[0,8]}' data-mw='{"parts":[{"template":{"target":{"wt":"Home","href":"./Template:Home"},"params":{},"i":0}}]}'><div class="lcs-container" data-parsoid="{}"><span about="#mwt1" data-parsoid="{}">
+</span><p about="#mwt1" data-parsoid="{}">Left column from the template.</p><span about="#mwt1" data-parsoid="{}">
+</span><div class="content" about="#mwt1" data-parsoid='{"stx":"html"}'>Foo</div><span about="#mwt1" data-parsoid="{}">
+</span></div></div><span about="#mwt1">
+</span><div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt1" data-parsoid='{"src":"&lt;mainpage-rightcolumn-start />"}' data-mw='{"name":"mainpage-rightcolumn-start","attrs":{}}'><div class="rcs-container" data-parsoid="{}"><span about="#mwt1" data-parsoid="{}">
+</span><p about="#mwt1" data-parsoid="{}">Right column from the template.</p><span about="#mwt1" data-parsoid="{}">
+</span></div></div>
+!! end
+
+!! test
+templated main page with preceding template content
+!! wikitext
+{{HomeWithOtherStuff}}
+!! html/parsoid
+<link rel="mw:PageProp/Category" href="./Category:Some_category" about="#mwt1" typeof="mw:Transclusion" data-parsoid='{"stx":"simple","a":{"href":"./Category:Some_category"},"sa":{"href":"Category:Some category"},"dsr":[0,22,null,null],"pi":[[]]}' data-mw='{"parts":[{"template":{"target":{"wt":"HomeWithOtherStuff","href":"./Template:HomeWithOtherStuff"},"params":{},"i":0}}]}'/><span about="#mwt1">
+</span><div class="main-page-tag-lcs main-page-tag-lcs-exploded" typeof="mw:Extension/mainpage-leftcolumn-start" about="#mwt1" data-parsoid='{"src":"&lt;mainpage-leftcolumn-start />"}' data-mw='{"name":"mainpage-leftcolumn-start","attrs":{}}'><div class="lcs-container" data-parsoid="{}"><span about="#mwt1" data-parsoid="{}">
+</span><p about="#mwt1" data-parsoid="{}">Left column from the template.</p><span about="#mwt1" data-parsoid="{}">
+</span><div class="content" about="#mwt1" data-parsoid='{"stx":"html"}'>Foo</div><span about="#mwt1" data-parsoid="{}">
+</span></div></div><span about="#mwt1">
+</span><div class="main-page-tag-rcs" typeof="mw:Extension/mainpage-rightcolumn-start" about="#mwt1" data-parsoid='{"src":"&lt;mainpage-rightcolumn-start />"}' data-mw='{"name":"mainpage-rightcolumn-start","attrs":{}}'><div class="rcs-container" data-parsoid="{}"><span about="#mwt1" data-parsoid="{}">
+</span><p about="#mwt1" data-parsoid="{}">Right column from the template.</p><span about="#mwt1" data-parsoid="{}">
+</span></div></div>
 !! end


### PR DESCRIPTION
Our current main page column tag handler crashes when trying to handle templated
main pages, since it tries to use the DSR offsets of the end column tag to
correct the DSR offsets for the start tag, but the end column tag will have no
offsets set in this scenario. Instead, make sure not to mess with DSRs if the
main page tags came from a transclusion - their DSR offsets will be correct in
the first place, since they will refer to the offsets of the template
transclusion in the main page wikitext, rather than the offsets of the tags in
the template wikitext, thereby requiring no adjustment. Add two parser tests for
templated main pages as well.

Ultimately, none of this code is idiomatic Parsoid; all the DSR etc. voodoo is
only needed to work around the fact that we use a separate "end tag" (that is,
`<mainpage-endcolumn />`) to close off main page columns, rather than going the
idiomatic way and having `<mainpage-leftcolumn>`...`</mainpage-leftcolumn>` tags
that can have wikitext content. In the latter case, Parsoid handling could be
achieved with either a trivial native extension or by the builtin fallback to
PHP parser handling.