### PR TITLE
CATS-687 | Enable compute workers and raise CPU request

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,13 @@ services:
         # IW-2729: Use batch API interface for communicating with MediaWiki
         useBatchAPI: true
 
+        # Enable using compute workers to parse requests.
+        useWorker: true
+        # The number of workers in the pool spawned by each http worker
+        # to call out for parsing
+        # ceil(cpu request / `num_workers`) + 1
+        cpu_workers: 3
+
         limits:
           wt2html:
             # IW-3041: Match Parsoid's max wikitext size to MediaWiki's $wgMaxArticleSize value - 2 MiB

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -55,7 +55,7 @@ spec:
             cpu: 5
             memory: 3Gi
           requests:
-            cpu: 1
+            cpu: 2
             memory: 2Gi
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Set Parsoid to use a dedicated worker pool for parsing wikitext, separate from
the main pool serving HTTP requests, to see if this helps with the stability
issues we've been having. Also bump CPU request slightly based on observed
utilization.