### PR TITLE
CATS-1086 | Refactor portable infobox parsing for robustness

### DIFF
--- a/lib/ext/Infobox/index.js
+++ b/lib/ext/Infobox/index.js
@@ -36,82 +36,152 @@ const toDOM = function(state, content, attributes) {
  * DOM post-processor that operates on the complete HTML5 document constructed by Parsoid from the input content.
  */
 class PostProcessingPortableInfoboxRenderer {
+
+	/**
+	 * Find portable infobox nodes within a given encapsulation wrapper
+	 * @generator
+	 * @param {Node} node within the encapsulation wrapper
+	 * @yields {Node} portable infobox nodes within this encapsulation wrapper
+	 */
+	*findInfoboxNodesWithinEncapsulationWrapper(node) {
+		if (DOMUtils.hasTypeOf(node, 'mw:Extension/infobox')) {
+			yield node;
+			return;
+		}
+
+		if (node.hasChildNodes()) {
+			for (let child = node.firstChild; child !== null; child = child.nextSibling) {
+				if (DOMUtils.isElt(child)) {
+					// Recurse into this DOM subtree
+					yield* this.findInfoboxNodesWithinEncapsulationWrapper(child);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Determines if the given DOM node is an encapsulation wrapper node associated with a given transclusion.
+	 * @param {Node|null} node - potential encapsulation wrapper node, or null
+	 * @param {string} transclusionAboutId - Parsoid about-ID of the associated transclusion
+	 * @return {boolean}
+	 */
+	isEncapsulationWrapperForSameTransclusion(node, transclusionAboutId) {
+		return node !== null && WTUtils.hasParsoidAboutId(node) && node.getAttribute('about') === transclusionAboutId;
+	}
+
+	/**
+	 * Extract all portable infobox nodes and associated template transclusions from the Parsoid DOM.
+	 * @generator
+	 * @param {Node} node
+	 * @yields {Node[]|Node[][]} 2-tuples of template transclusions and infoboxes inside them
+	 */
+	*extractTranscludedInfoboxNodes(node) {
+		let nextChild;
+		for (let child = node.firstChild; child !== null; child = nextChild) {
+			nextChild = child.nextSibling;
+
+			if (!DOMUtils.isElt(child)) {
+				continue;
+			}
+
+			// Since portable infoboxes can only render data when used via a template transclusion,
+			// only look for portable infoboxes when a transclusion context exists.
+			if (DOMUtils.hasTypeOf(child, 'mw:Transclusion')) {
+				const infoboxNodes = [];
+				const aboutId = child.getAttribute('about');
+				let sibling = child;
+
+				// Make sure to process all encapsulation wrappers associated with this transclusion,
+				// since they may contain portable infoboxes or be portable infobox nodes themselves.
+				while (this.isEncapsulationWrapperForSameTransclusion(sibling, aboutId)) {
+					nextChild = sibling.nextSibling;
+
+					for (const childInfoboxNode of this.findInfoboxNodesWithinEncapsulationWrapper(sibling)) {
+						infoboxNodes.push(childInfoboxNode);
+					}
+
+					sibling = nextChild;
+				}
+
+				if (infoboxNodes.length > 0) {
+					yield [child, infoboxNodes];
+				}
+
+				continue;
+			}
+
+			// Recurse into this DOM subtree
+			if (child.hasChildNodes()) {
+				yield* this.extractTranscludedInfoboxNodes(child);
+			}
+		}
+	}
+
+	/**
+	 * Extract rendered portable infoboxes from the PHP parser's output, and mount them to the Parsoid document.
+	 * @param {Node} node
+	 * @param {Node[]} infoboxNodes
+	 */
+	attachParsedInfoboxHtml(node, infoboxNodes) {
+		for (let child = node.firstChild; child !== null; child = child.nextSibling) {
+			if (!DOMUtils.isElt(child)) {
+				continue;
+			}
+
+			// Mount each portable infobox in the PHP parser's HTML to the associated (by index)
+			// infobox node in the Parsoid document.
+			if (child.classList.contains('portable-infobox')) {
+				const origNode = infoboxNodes.shift();
+				const imported = origNode.ownerDocument.importNode(child, true);
+
+				origNode.appendChild(imported);
+				continue;
+			}
+
+			// Recurse into this DOM subtree
+			if (child.hasChildNodes()) {
+				this.attachParsedInfoboxHtml(child, infoboxNodes);
+			}
+		}
+	}
+
+	/**
+	 * Find portable infoboces associated with template transclusions in the document,
+	 * and render them via the PHP parser
+	 */
 	run(node, env, options, atTopLevel) {
 		if (!atTopLevel) {
 			return;
 		}
 
-		const document = node.ownerDocument;
-		const potentialInfoboxNodes = Array.from(document.getElementsByTagName('aside'));
-
-		// array of [transclusionStartNode,infoboxNode] 2-tuples
-		const infoboxTransclusions = [];
-
-		potentialInfoboxNodes.forEach((node) => {
-			// Only handle actual infoboxes and not any <aside> tags
-			if (!DOMUtils.hasTypeOf(node, 'mw:Extension/infobox')) {
-				return;
-			}
-
-			// If the current node is part of a template transclusion, find the starting node of the transclusion.
-			// Typically this will be the same node as the infobox itself, but this may not be the case if there is
-			// additional content in the template before the infobox, e.g. a category link.
-			const transclusionStartNode = WTUtils.findFirstEncapsulationWrapperNode(node);
-
-			if (transclusionStartNode && DOMUtils.hasTypeOf(transclusionStartNode, 'mw:Transclusion')) {
-				// Found an <infobox> included on the page as a template - we can handle it
-				infoboxTransclusions.push([transclusionStartNode, node]);
-			}
-		});
-
 		const infoboxParseRequests = [];
 
-		/**
-		 * Create a wikitext template invocation and push it to the queue of infoboxes to be parsed
-		 * @param {Object} template template transclusion metadata from Parsoid
-		 */
-		const pushWikitextTemplateInvocation = ({ template }) => {
-			// build wikitext for transclusion params
-			const paramsAsText = Object.entries(template.params).reduce(
+		for (const infoboxTransclusion of this.extractTranscludedInfoboxNodes(node)) {
+			const [transclusionStartNode, infoboxNodes] = infoboxTransclusion;
+
+			const { parts } = DOMDataUtils.getDataMw(transclusionStartNode);
+			const [templateInvocation] = parts;
+			const { template } = templateInvocation;
+			const { params } = template;
+
+			const paramsAsText = Object.entries(params).reduce(
 				(accum, [paramName, value]) => accum + `|${paramName}=${value.wt}`, ''
 			);
 
+			// Call the PHP parser to render this infobox for us
 			const invocation = `{{${template.target.wt}${paramsAsText}}}`;
 			const phpParseRequest = env.batcher.parse(env.page.name, invocation);
 
-			infoboxParseRequests.push(phpParseRequest);
-		};
+			const infoboxParseRequest = phpParseRequest.then((htmlContents) => {
+				const docFromMw = DOMUtils.parseHTML(htmlContents);
 
-		// Process each <infobox> template transclusion and issue a request to render them via the MW PHP parser
-		infoboxTransclusions.forEach(([transclusionStartNode]) => {
-			const { parts } = DOMDataUtils.getDataMw(transclusionStartNode);
-			const [templateInvocation] = parts;
-
-			pushWikitextTemplateInvocation(templateInvocation);
-		});
-
-		// Parse all infoboxes in parallel and inject their contents back into the document
-		return Promise.all(infoboxParseRequests)
-			.then((htmlContents) => {
-				htmlContents.forEach((html, i) => {
-					const docFromMw = DOMUtils.parseHTML(html);
-
-					// only import the infobox and discard other template contents to avoid duplication
-					let portableInfobox = docFromMw.querySelector('.portable-infobox');
-
-					if (portableInfobox === undefined) {
-						// if infobox is empty and does not render anything, lets create a placeholder for it
-						portableInfobox = document.createElement('aside');
-						portableInfobox.setAttribute('class', 'portable-infobox portable-infobox-placeholder');
-					}
-
-					const imported = document.importNode(portableInfobox, true);
-					const [,infoboxNode] = infoboxTransclusions[i];
-
-					// add the rendered infobox to the output document in the proper location
-					infoboxNode.appendChild(imported);
-				});
+				this.attachParsedInfoboxHtml(docFromMw.body, infoboxNodes);
 			});
+
+			infoboxParseRequests.push(infoboxParseRequest);
+		}
+
+		return Promise.all(infoboxParseRequests);
 	}
 }
 

--- a/tests/infoboxParserTests.txt
+++ b/tests/infoboxParserTests.txt
@@ -1,0 +1,129 @@
+# Force the test runner to ensure the extension is loaded
+!! hooks
+infobox
+!! endhooks
+
+!! article
+Template:PortableInfoboxSample
+!! text
+<infobox type="characteralt">
+	<title source="name"><default>Default</default></title>
+	<image source="image"/>
+	<header><center>Biographical information</center></header>
+	<data source="spoken"><label>spoken</label></data>
+	<data source="alias"><label>Aliases</label></data>
+	<data source="classification"><label>Species</label></data>
+	<data source="gender"><label>Gender</label></data>
+	<data source="age"><label>Age</label></data>
+	<header><center>Status</center></header>
+	<data source="status"><label>Status</label></data>
+	<data source="family"><label>Family</label></data>
+	<data source="occupation"><label>Occupation</label></data>
+	<data source="affiliations"><label>Affiliation</label></data>
+	<data source="allies"><label>Allies</label></data>
+</infobox>
+!! endarticle
+
+!! article
+Template:PortableInfoboxWrapped
+!! text
+<div class="conjoined-infoboxes" style="float: right; clear: none;">
+<infobox type="characteralt">
+	<title source="name"><default>Default</default></title>
+	<image source="image"/>
+	<header><center>Biographical information</center></header>
+	<data source="spoken"><label>spoken</label></data>
+	<data source="alias"><label>Aliases</label></data>
+	<data source="classification"><label>Species</label></data>
+	<data source="gender"><label>Gender</label></data>
+	<data source="age"><label>Age</label></data>
+	<header><center>Status</center></header>
+	<data source="status"><label>Status</label></data>
+	<data source="family"><label>Family</label></data>
+	<data source="occupation"><label>Occupation</label></data>
+	<data source="affiliations"><label>Affiliation</label></data>
+	<data source="allies"><label>Allies</label></data>
+</infobox>
+</div>
+!! endarticle
+
+!! article
+Template:PortableInfoboxWithCategory
+!! text
+[[Category:InfoboxCategory]]
+<infobox type="characteralt">
+	<title source="name"><default>Default</default></title>
+	<image source="image"/>
+	<header><center>Biographical information</center></header>
+	<data source="spoken"><label>spoken</label></data>
+	<data source="alias"><label>Aliases</label></data>
+	<data source="classification"><label>Species</label></data>
+	<data source="gender"><label>Gender</label></data>
+	<data source="age"><label>Age</label></data>
+	<header><center>Status</center></header>
+	<data source="status"><label>Status</label></data>
+	<data source="family"><label>Family</label></data>
+	<data source="occupation"><label>Occupation</label></data>
+	<data source="affiliations"><label>Affiliation</label></data>
+	<data source="allies"><label>Allies</label></data>
+</infobox>
+!! endarticle
+
+!! article
+Template:PortableInfoboxWrappedWithCategory
+!! text
+[[Category:InfoboxCategory]]
+<div class="conjoined-infoboxes" style="float: right; clear: none;">
+<infobox type="characteralt">
+	<title source="name"><default>Default</default></title>
+	<image source="image"/>
+	<header><center>Biographical information</center></header>
+	<data source="spoken"><label>spoken</label></data>
+	<data source="alias"><label>Aliases</label></data>
+	<data source="classification"><label>Species</label></data>
+	<data source="gender"><label>Gender</label></data>
+	<data source="age"><label>Age</label></data>
+	<header><center>Status</center></header>
+	<data source="status"><label>Status</label></data>
+	<data source="family"><label>Family</label></data>
+	<data source="occupation"><label>Occupation</label></data>
+	<data source="affiliations"><label>Affiliation</label></data>
+	<data source="allies"><label>Allies</label></data>
+</infobox>
+</div>
+!! endarticle
+
+!! test
+basic infobox transclusion
+!! wikitext
+{{PortableInfoboxSample|name=Foo|alias=Bar|status=Active}}
+!! html/parsoid
+<p class="mw-empty-elt" data-parsoid='{"autoInsertedEnd":true,"dsr":[0,0,0,0]}'></p><aside typeof="mw:Extension/infobox mw:Transclusion" about="#mwt1" data-parsoid='{"empty":true,"pi":[[{"k":"name","named":true},{"k":"alias","named":true},{"k":"status","named":true}]],"dsr":[0,58]}' data-mw='{"parts":[{"template":{"target":{"wt":"PortableInfoboxSample","href":"./Template:PortableInfoboxSample"},"params":{"name":{"wt":"Foo"},"alias":{"wt":"Bar"},"status":{"wt":"Active"}},"i":0}}]}'><aside class="portable-infobox" data-parsoid="{}">This is some mock portable infobox HTML from the server</aside></aside><p class="mw-empty-elt" data-parsoid='{"autoInsertedStart":true,"dsr":[58,58,0,0]}'></p>
+!! end
+
+!! test
+infobox wrapped in HTML tag (CATS-1086)
+!! wikitext
+{{PortableInfoboxWrapped|name=Foo|alias=Bar|status=Active}}
+!! html/parsoid
+<div class="conjoined-infoboxes" typeof="mw:Transclusion" data-mw='{"parts":[{"template":{"target":{"wt":"PortableInfoboxWrapped","href":"./Template:PortableInfoboxWrapped"},"params":{"name":{"wt":"Foo"},"alias":{"wt":"Bar"},"status":{"wt":"Active"}},"i":0}}]}'><aside typeof="mw:Extension/infobox" data-mw='{"name":"infobox","attrs":{"type":"characteralt"},"body":{"extsrc":"\n\t&lt;title source=\"name\">&lt;default>Default&lt;/default>&lt;/title>\n\t&lt;image source=\"image\"/>\n\t&lt;header>&lt;center>Biographical information&lt;/center>&lt;/header>\n\t&lt;data source=\"spoken\">&lt;label>spoken&lt;/label>&lt;/data>\n\t&lt;data source=\"alias\">&lt;label>Aliases&lt;/label>&lt;/data>\n\t&lt;data source=\"classification\">&lt;label>Species&lt;/label>&lt;/data>\n\t&lt;data source=\"gender\">&lt;label>Gender&lt;/label>&lt;/data>\n\t&lt;data source=\"age\">&lt;label>Age&lt;/label>&lt;/data>\n\t&lt;header>&lt;center>Status&lt;/center>&lt;/header>\n\t&lt;data source=\"status\">&lt;label>Status&lt;/label>&lt;/data>\n\t&lt;data source=\"family\">&lt;label>Family&lt;/label>&lt;/data>\n\t&lt;data source=\"occupation\">&lt;label>Occupation&lt;/label>&lt;/data>\n\t&lt;data source=\"affiliations\">&lt;label>Affiliation&lt;/label>&lt;/data>\n\t&lt;data source=\"allies\">&lt;label>Allies&lt;/label>&lt;/data>\n"}}'><aside class="portable-infobox">This is some mock portable infobox HTML from the server</aside></aside></div>
+!! end
+
+!! test
+infobox with category before infobox tag (CATS-270)
+!! wikitext
+{{PortableInfoboxWithCategory|name=Foo|alias=Bar|status=Active}}
+!! html/parsoid
+<link rel="mw:PageProp/Category" href="./Category:InfoboxCategory" about="#mwt1" typeof="mw:Transclusion" data-parsoid='{"stx":"simple","a":{"href":"./Category:InfoboxCategory"},"sa":{"href":"Category:InfoboxCategory"},"dsr":[0,64,null,null],"pi":[[{"k":"name","named":true},{"k":"alias","named":true},{"k":"status","named":true}]]}' data-mw='{"parts":[{"template":{"target":{"wt":"PortableInfoboxWithCategory","href":"./Template:PortableInfoboxWithCategory"},"params":{"name":{"wt":"Foo"},"alias":{"wt":"Bar"},"status":{"wt":"Active"}},"i":0}}]}'/><span about="#mwt1">
+</span><aside typeof="mw:Extension/infobox" about="#mwt1" data-parsoid='{"empty":true,"src":"&lt;infobox type=\"characteralt\">\n\t&lt;title source=\"name\">&lt;default>Default&lt;/default>&lt;/title>\n\t&lt;image source=\"image\"/>\n\t&lt;header>&lt;center>Biographical information&lt;/center>&lt;/header>\n\t&lt;data source=\"spoken\">&lt;label>spoken&lt;/label>&lt;/data>\n\t&lt;data source=\"alias\">&lt;label>Aliases&lt;/label>&lt;/data>\n\t&lt;data source=\"classification\">&lt;label>Species&lt;/label>&lt;/data>\n\t&lt;data source=\"gender\">&lt;label>Gender&lt;/label>&lt;/data>\n\t&lt;data source=\"age\">&lt;label>Age&lt;/label>&lt;/data>\n\t&lt;header>&lt;center>Status&lt;/center>&lt;/header>\n\t&lt;data source=\"status\">&lt;label>Status&lt;/label>&lt;/data>\n\t&lt;data source=\"family\">&lt;label>Family&lt;/label>&lt;/data>\n\t&lt;data source=\"occupation\">&lt;label>Occupation&lt;/label>&lt;/data>\n\t&lt;data source=\"affiliations\">&lt;label>Affiliation&lt;/label>&lt;/data>\n\t&lt;data source=\"allies\">&lt;label>Allies&lt;/label>&lt;/data>\n&lt;/infobox>"}' data-mw='{"name":"infobox","attrs":{"type":"characteralt"},"body":{"extsrc":"\n\t&lt;title source=\"name\">&lt;default>Default&lt;/default>&lt;/title>\n\t&lt;image source=\"image\"/>\n\t&lt;header>&lt;center>Biographical information&lt;/center>&lt;/header>\n\t&lt;data source=\"spoken\">&lt;label>spoken&lt;/label>&lt;/data>\n\t&lt;data source=\"alias\">&lt;label>Aliases&lt;/label>&lt;/data>\n\t&lt;data source=\"classification\">&lt;label>Species&lt;/label>&lt;/data>\n\t&lt;data source=\"gender\">&lt;label>Gender&lt;/label>&lt;/data>\n\t&lt;data source=\"age\">&lt;label>Age&lt;/label>&lt;/data>\n\t&lt;header>&lt;center>Status&lt;/center>&lt;/header>\n\t&lt;data source=\"status\">&lt;label>Status&lt;/label>&lt;/data>\n\t&lt;data source=\"family\">&lt;label>Family&lt;/label>&lt;/data>\n\t&lt;data source=\"occupation\">&lt;label>Occupation&lt;/label>&lt;/data>\n\t&lt;data source=\"affiliations\">&lt;label>Affiliation&lt;/label>&lt;/data>\n\t&lt;data source=\"allies\">&lt;label>Allies&lt;/label>&lt;/data>\n"}}'><aside class="portable-infobox" data-parsoid="{}">This is some mock portable infobox HTML from the server</aside></aside><p class="mw-empty-elt" data-parsoid='{"autoInsertedStart":true,"dsr":[64,64,0,0]}'></p>
+!! end
+
+!! test
+wrapped infobox with category before wrapper tag
+!! wikitext
+{{PortableInfoboxWrappedWithCategory|name=Foo|alias=Bar|status=Active}}
+!! html/parsoid
+<link rel="mw:PageProp/Category" href="./Category:InfoboxCategory" about="#mwt1" typeof="mw:Transclusion" data-parsoid='{"stx":"simple","a":{"href":"./Category:InfoboxCategory"},"sa":{"href":"Category:InfoboxCategory"},"dsr":[0,71,null,null],"pi":[[{"k":"name","named":true},{"k":"alias","named":true},{"k":"status","named":true}]]}' data-mw='{"parts":[{"template":{"target":{"wt":"PortableInfoboxWrappedWithCategory","href":"./Template:PortableInfoboxWrappedWithCategory"},"params":{"name":{"wt":"Foo"},"alias":{"wt":"Bar"},"status":{"wt":"Active"}},"i":0}}]}'/><span about="#mwt1">
+</span><div class="conjoined-infoboxes" style="float: right; clear: none;" about="#mwt1" data-parsoid='{"stx":"html"}'>
+<aside typeof="mw:Extension/infobox" about="#mwt4" data-parsoid='{"empty":true,"src":"&lt;infobox type=\"characteralt\">\n\t&lt;title source=\"name\">&lt;default>Default&lt;/default>&lt;/title>\n\t&lt;image source=\"image\"/>\n\t&lt;header>&lt;center>Biographical information&lt;/center>&lt;/header>\n\t&lt;data source=\"spoken\">&lt;label>spoken&lt;/label>&lt;/data>\n\t&lt;data source=\"alias\">&lt;label>Aliases&lt;/label>&lt;/data>\n\t&lt;data source=\"classification\">&lt;label>Species&lt;/label>&lt;/data>\n\t&lt;data source=\"gender\">&lt;label>Gender&lt;/label>&lt;/data>\n\t&lt;data source=\"age\">&lt;label>Age&lt;/label>&lt;/data>\n\t&lt;header>&lt;center>Status&lt;/center>&lt;/header>\n\t&lt;data source=\"status\">&lt;label>Status&lt;/label>&lt;/data>\n\t&lt;data source=\"family\">&lt;label>Family&lt;/label>&lt;/data>\n\t&lt;data source=\"occupation\">&lt;label>Occupation&lt;/label>&lt;/data>\n\t&lt;data source=\"affiliations\">&lt;label>Affiliation&lt;/label>&lt;/data>\n\t&lt;data source=\"allies\">&lt;label>Allies&lt;/label>&lt;/data>\n&lt;/infobox>"}' data-mw='{"name":"infobox","attrs":{"type":"characteralt"},"body":{"extsrc":"\n\t&lt;title source=\"name\">&lt;default>Default&lt;/default>&lt;/title>\n\t&lt;image source=\"image\"/>\n\t&lt;header>&lt;center>Biographical information&lt;/center>&lt;/header>\n\t&lt;data source=\"spoken\">&lt;label>spoken&lt;/label>&lt;/data>\n\t&lt;data source=\"alias\">&lt;label>Aliases&lt;/label>&lt;/data>\n\t&lt;data source=\"classification\">&lt;label>Species&lt;/label>&lt;/data>\n\t&lt;data source=\"gender\">&lt;label>Gender&lt;/label>&lt;/data>\n\t&lt;data source=\"age\">&lt;label>Age&lt;/label>&lt;/data>\n\t&lt;header>&lt;center>Status&lt;/center>&lt;/header>\n\t&lt;data source=\"status\">&lt;label>Status&lt;/label>&lt;/data>\n\t&lt;data source=\"family\">&lt;label>Family&lt;/label>&lt;/data>\n\t&lt;data source=\"occupation\">&lt;label>Occupation&lt;/label>&lt;/data>\n\t&lt;data source=\"affiliations\">&lt;label>Affiliation&lt;/label>&lt;/data>\n\t&lt;data source=\"allies\">&lt;label>Allies&lt;/label>&lt;/data>\n"}}'><aside class="portable-infobox" data-parsoid="{}">This is some mock portable infobox HTML from the server</aside></aside>
+!! end

--- a/tests/mockAPI.js
+++ b/tests/mockAPI.js
@@ -570,6 +570,12 @@ var parse = function(text, onlypst, formatversion) {
 	if (onlypst) {
 		return fmt(text.replace(/\{\{subst:echo\|([^}]+)\}\}/, "$1"));
 	}
+
+	// Fandom change: Return mock HTML for use in portable infobox parsing tests
+	if (text.indexOf('{{PortableInfobox') !== -1) {
+		return fmt('<aside class="portable-infobox">This is some mock portable infobox HTML from the server</aside>');
+	}
+
 	// Render to html the contents of known extension tags
 	var match = text.match(/<([A-Za-z][^\t\n\v />\0]*)/);
 	switch ((match && match[1]) || '') {

--- a/tests/parserTests.json
+++ b/tests/parserTests.json
@@ -29,5 +29,6 @@
 	},
 	"mainPageTagParserTests.txt": {
 
-	}
+	},
+	"infoboxParserTests.txt": {}
 }


### PR DESCRIPTION
Portable infoboxes need access to the current parser frame so that they can use
template parameters for rendering infobox data. To support this, we implement
portable infobox parsing in Parsoid using an HTML post-processor that runs after
Parsoid has assembled a mostly-ready DOM for the article being parsed. This
processor looks for portable infoboxes within the DOM, finds associated template
transclusion parameters, and calls out to the PHP parser to perform the actual
rendering.

The current logic proactively looks for <aside> node (the root element of
portable infoboxes), then checks if the node itself or one of its siblings is an
associated template transclusion. This fails to account for the case where the
infobox may be "buried" as a child node of a different node within the template
transclusion - in this case, the associated template transclusion may be an
ancestor of the infobox node, or a sibling of one of its ancestors.

As such, refactor portable infobox parsing to look for template transclusions
first and then try to find associated portable infoboxes (which may be the
transclusion node itself, a sibling of the transclusion node, a child of the
transclusion node, or a child of one of the transclusion node's siblings),
rather than the other way around. Incidentally, this should also correctly
handle the rare (but theoretically possible) case where a template transclusion
has multiple associated portable infoboxes; the current logic would always use
the rendered HTML of the first infobox if such a situation occurred.

Also add some basic parser tests for portable infobox parsing.