### PR TITLE
CATS-687 | Use a size-limited cache for wiki configs

### DIFF
--- a/lib/config/MWParserEnvironment.js
+++ b/lib/config/MWParserEnvironment.js
@@ -10,6 +10,7 @@
 
 require('../../core-upgrade.js');
 
+var LRU = require('lru-cache');
 var semver = require('semver');
 var Title = require('mediawiki-title').Title;
 var Promise = require('../utils/promise.js');
@@ -424,7 +425,10 @@ MWParserEnvironment.prototype.configureLogging = function() {
 
 MWParserEnvironment.resetConfCache = function() {
 	// Cache for wiki configurations, shared between requests.
-	MWParserEnvironment.prototype.confCache = {};
+	MWParserEnvironment.prototype.confCache = new LRU({
+		max: 1024,
+		maxAge: 1000 * 60 * 5 // 5 minutes
+	});
 };
 MWParserEnvironment.resetConfCache();
 
@@ -635,8 +639,10 @@ MWParserEnvironment.prototype.switchToConfig = Promise.async(function *(prefix, 
 	if (!prefix || !parsoidConfig.mwApiMap.has(prefix)) {
 		throw new Error('No API URI available for prefix: ' + prefix);
 	} else {
-		if (!noCache && env.confCache[prefix]) {
-			env.conf.wiki = env.confCache[prefix];
+		// Fandom change: use a limited-size cache for wiki configs
+		var cachedConfig = env.confCache.get(prefix);
+		if (!noCache && cachedConfig) {
+			env.conf.wiki = cachedConfig;
 			env.conf.wiki.loadGamepediaExtensions(env);
 			return; // done!
 		} else if (parsoidConfig.fetchConfig) {
@@ -657,7 +663,7 @@ MWParserEnvironment.prototype.switchToConfig = Promise.async(function *(prefix, 
 
 	env.conf.wiki = new WikiConfig(parsoidConfig, resultConf, prefix);
 	env.conf.wiki.loadGamepediaExtensions(env);
-	env.confCache[prefix] = env.conf.wiki;
+	env.confCache.set(prefix, env.conf.wiki);
 	if (parsoidConfig.fetchConfig) {
 		yield env.conf.wiki.detectFeatures(env);
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -616,6 +616,24 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "dashdash": {
@@ -2336,13 +2354,11 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^4.0.0"
       }
     },
     "lunr": {
@@ -3644,10 +3660,9 @@
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express-handlebars": "^3.0.0",
     "finalhandler": "^1.1.1",
     "js-yaml": "^3.13.1",
+    "lru-cache": "^6.0.0",
     "mediawiki-title": "git+https://github.com/Wikia/mediawiki-title.git#v0.6.6",
     "negotiator": "git+https://github.com/arlolra/negotiator.git#full-parse-access",
     "pn": "^1.1.0",


### PR DESCRIPTION
Parsoid caches configuration for each wiki in memory without expiry/GC. Let's
make sure there's a maximum size and age for entries in this cache to avoid
uncontrolled resource consumption.