### PR TITLE
CATS-687 | Run parsoid with --inspect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.20.1-alpine
+FROM artifactory.wikia-inc.com/dockerhub/node:10.24.1-alpine
 
 RUN apk add --no-cache git python make g++
 
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY package.json package-lock.json /app/
 RUN npm ci --production
 
-FROM node:10.20.1-alpine
+FROM artifactory.wikia-inc.com/dockerhub/node:10.24.1-alpine
 
 EXPOSE 8080
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "lint": "npm run dump-tokenizer && npm run eslint",
-    "start": "service-runner",
+    "start": "node --inspect node_modules/.bin/service-runner",
     "eslint": "eslint bin lib tests tools core-upgrade.js",
     "eslint-fix": "eslint --fix bin lib tests tools core-upgrade.js",
     "dump-tokenizer": "npm run dump-tokenizer-source && npm run dump-tokenizer-rules",


### PR DESCRIPTION
This will allow us to attach an inspector such as Chrome's devtools to
introspect the application.

Also use a mirrored image for node.js, to avoid potential issues from relying on
Docker Hub images that may be ratelimited.