### PR TITLE
CATS-687 | Use a single process without Parsoid

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 worker_heartbeat_timeout: 300000
-num_workers: 2
+num_workers: 0
 
 logging:
     level: info


### PR DESCRIPTION
Right now the inspector only sees the master process for the cluster, while we
want to debug the workers.