### PR TITLE
CATS-687 | Raise concurrent request limit from 5 to 8

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,8 @@ services:
         # ceil(cpu request / `num_workers`) + 1
         cpu_workers: 3
 
+        maxConcurrentCalls: 8
+
         limits:
           wt2html:
             # IW-3041: Match Parsoid's max wikitext size to MediaWiki's $wgMaxArticleSize value - 2 MiB

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "lint": "npm run dump-tokenizer && npm run eslint",
-    "start": "node --inspect node_modules/.bin/service-runner",
+    "start": "service-runner",
     "eslint": "eslint bin lib tests tools core-upgrade.js",
     "eslint-fix": "eslint --fix bin lib tests tools core-upgrade.js",
     "dump-tokenizer": "npm run dump-tokenizer-source && npm run dump-tokenizer-rules",


### PR DESCRIPTION
We occasionally see some requests get rejected because a given instance has
reached its maximum capacity (5 * 3 workers = 15 concurrent requests). Let's
increase this limit to see if it helps with the problem.

Also disable the inspector as we won't be using it now.