### PR TITLE
CATS-2054 | Introduce unified HTTP response duration timer

### DIFF
--- a/lib/api/ParsoidService.js
+++ b/lib/api/ParsoidService.js
@@ -183,6 +183,19 @@ ParsoidService.init = Promise.async(function *(parsoidOptions, processLogger) {
 			omitLabelNames: true
 		}
 	});
+	var httpResponseDuration = parsoidConfig.metrics && parsoidConfig.metrics.makeMetric({
+		type: 'Histogram',
+		name: 'parsoid.http.response.duration',
+		prometheus: {
+			name: 'parsoid_http_response_duration_seconds',
+			help: 'HTTP response duration in seconds',
+			buckets: [ 0.05, 0.1, 0.3, 1, 3, 5, 10 ]
+		},
+		labels: {
+			names: [],
+			omitLabelNames: true
+		}
+	});
 
 	var normalizeHttpStatus = function(statusCode) {
 		if (!statusCode) {
@@ -216,7 +229,10 @@ ParsoidService.init = Promise.async(function *(parsoidOptions, processLogger) {
 			};
 			send = function() {
 				var code = normalizeHttpStatus(res.statusCode);
+				var elapsed = JSUtils.elapsedTime(res.locals.start);
+
 				httpResponseCount.increment(1, [code]);
+				httpResponseDuration.timing(elapsed / 1000);
 				clear();
 			};
 			res.once('finish', send);


### PR DESCRIPTION
Add a generic histogram to measure response times for all HTTP
responses, so that it can be used in the dashboard instead of the more
granular wt2html/html2wt ones.