### PR TITLE
Get rid of core-js

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-      - run: npm ci
+      - run: npm ci --no-optional
       - run: npm test
         env:
           CI: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 # install npm packages
 COPY package.json package-lock.json /app/
-RUN npm ci --production
+RUN npm ci --production --no-optional
 
 COPY . /app
 

--- a/core-upgrade.js
+++ b/core-upgrade.js
@@ -7,11 +7,6 @@ require('pn/_promise')(Promise); // This only needs to be done once.
 // Comments below annotate the highest lts version of node for which the
 // polyfills are necessary.  Remove when that version is no longer supported.
 
-// v6
-require('core-js/fn/object/entries');
-require('core-js/fn/string/pad-start');
-require('core-js/fn/string/pad-end');
-
 // In Node v10, console.assert() was changed to log messages to stderr
 // *WITHOUT THROWING AN EXCEPTION*.  We should clearly have been using
 // a proper assertion library... but since we're switching to PHP anyway,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "compression": "^1.7.2",
         "connect-busboy": "^0.0.2",
         "content-type": "git+https://git@github.com/wikimedia/content-type.git#master",
-        "core-js": "^2.5.6",
         "domino": "^2.1.0",
         "entities": "^1.1.1",
         "express": "^4.16.3",
@@ -768,11 +767,12 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "optional": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -5365,9 +5365,10 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "optional": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "compression": "^1.7.2",
     "connect-busboy": "^0.0.2",
     "content-type": "git+https://git@github.com/wikimedia/content-type.git#master",
-    "core-js": "^2.5.6",
     "domino": "^2.1.0",
     "entities": "^1.1.1",
     "express": "^4.16.3",


### PR DESCRIPTION
core-js is EOL, spews deprecation warnings in install logs, and is only
used to polyfill some methods on Node < 6. Let's get rid of it. prfun
still specifies it as an optionalDependency, so make sure we use
--no-optional when installing dependencies for the production docker
image and in CI.