### PR TITLE
CATS-2294 | Update team label and alerts configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,8 +74,7 @@ node('docker-daemon'){
                     'imageName':imageName,
                     'datacenter': datacenter,
                     'severity': isDevEnv ? 'warning' : 'critical',
-                    'send_pd': !isDevEnv ? 'send' : '""',
-                    'slack_channel': 'cats-alerts'
+                    'send_pd': !isDevEnv ? 'send' : '""'
             ]).toString())
         }
 

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     app: unified-platform-parsoid
-    team: iwing
+    team: cats
   name: unified-platform-parsoid
   namespace: ${env}
 spec:
@@ -28,7 +28,7 @@ metadata:
   name: unified-platform-parsoid
   namespace: ${env}
   labels:
-    team: iwing
+    team: cats
 spec:
   selector:
     matchLabels:
@@ -44,7 +44,7 @@ spec:
     metadata:
       labels:
         app: unified-platform-parsoid
-        team: iwing
+        team: cats
     spec:
       containers:
       - name: unified-platform-parsoid
@@ -94,7 +94,7 @@ metadata:
   name: unified-platform-parsoid
   namespace: ${env}
   labels:
-    team: iwing
+    team: cats
   annotations:
     kubernetes.io/ingress.class: external-lb-a
 spec:
@@ -117,7 +117,7 @@ metadata:
   name: unified-platform-parsoid
   labels:
     app: unified-platform-parsoid
-    team: iwing
+    team: cats
   namespace: ${env}
 spec:
   jobLabel: app
@@ -139,7 +139,7 @@ metadata:
   labels:
     prometheus: ${env}
     role: alert-rules
-    team: iwing
+    team: cats
   name: unified-platform-parsoid
   namespace: ${env}
 spec:
@@ -150,8 +150,7 @@ spec:
           expr: absent(kube_deployment_status_replicas_available{deployment="unified-platform-parsoid"} > 0)
           labels:
             severity: $severity
-            team: iwing
-            slack_channel: $slack_channel
+            team: cats
             pd: ${send_pd}
           annotations:
             description: Parsoid service is down
@@ -162,6 +161,5 @@ spec:
           expr: sum(increase(kube_pod_container_status_restarts_total{container="unified-platform-parsoid"}[1h])) > 5
           labels:
             severity: warning
-            team: iwing
-            slack_channel: $slack_channel
+            team: cats
             pd: ""


### PR DESCRIPTION
Set proper (CATS) team label and use newly added alert routing.