### PR TITLE
Set explicitly security context to be compliant with Pod Security Standards

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -86,6 +86,14 @@ spec:
         - containerPort: 8080
         - containerPort: 8081
           name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
 
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
This is part of migration from PodSecurityPolicy to the PodSecurity Admission Controller [1]. Some security parameters which are implicitly injected by PodSecurityPolicy mutating admission webhooks, need to be explicitly set to be compliant with Pod Security Standards [2].
Adding those security parameters don't change how workload is functioning because currently they are injected into manifest spec during Pod creation.

[1] https://fandom.atlassian.net/browse/OPS-13747
[2] https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted