### PR TITLE
PLATFORM-7469 | Scale-down production deployments for the service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker-daemon'){
         imageName = "artifactory.wikia-inc.com/services/unified-platform-parsoid:${serviceVersion}"
 
         stage('Generate Descriptors'){
-            def replicas = isDevEnv ? 1 : 10
+            def replicas = isDevEnv ? 1 : 2
 
             def parsoidConfiguration = readFile "k8s.yaml"
 

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -33,7 +33,7 @@ spec:
   selector:
     matchLabels:
       app: unified-platform-parsoid
-  replicas: $replicas
+    replicas: $replicas
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -69,10 +69,10 @@ spec:
               divisor: 1Mi
         resources:
           limits:
-            cpu: 5
+            cpu: 2
             memory: 6Gi
           requests:
-            cpu: 2
+            cpu: 0.2
             memory: 3Gi
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/PLATFORM-7469
* https://fandom.atlassian.net/browse/CATS-2884

## Description
This service is almost not used on production and should be soon sunset. Till then as there is very limited traffic we should scale down the service, so it's not reserving ~25 CPU cores in our DC.

## Who might be interested?
@Wikia/platform-team @Wikia/cats